### PR TITLE
Divert Cognito region from cognito identity pool id.

### DIFF
--- a/src/cognito/index.ts
+++ b/src/cognito/index.ts
@@ -11,8 +11,12 @@ import { AwsCredentialIdentity } from "@aws-sdk/types";
  * @param identityPoolId Cognito Identity Pool Id
  */
 export async function withIdentityPoolId(identityPoolId: string): Promise<MapAuthHelper & SDKAuthHelper> {
+  const region = identityPoolId.split(":")[0];
   const credentialsProvider = fromCognitoIdentityPool({
     identityPoolId,
+    clientConfig: {
+      region,
+    },
   });
 
   let credentials: AwsCredentialIdentity;


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Cognito credential provider needs region to setup cognito client. Divert it from the cognito identity pool id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
