### PR TITLE
Improve bundling, esp. for browsers (+ via unpkg)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   "engines": {
     "node": ">= 16.0.0"
   },
+  "browser": "./dist/amazonLocationAuthHelper.js",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
+  "unpkg": "./dist/amazonLocationAuthHelper.js",
   "types": "./dist/types/index.d.ts",
   "files": [
     "./LICENSE.txt",


### PR DESCRIPTION
_Issue #, if available:_ n/a

_Description of changes:_

Specify that the UMD build should be used for browsers (and unpkg).

Effects:

1. `https://www.unpkg.com/@aws/amazon-location-utilities-auth-helper@1` should start redirecting to the UMD build: `https://www.unpkg.com/browse/@aws/amazon-location-utilities-auth-helper@<version>/dist/amazonLocationAuthHelper.js`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
