### PR TITLE
Extend withIdentityPoolId signature to allow usage of authenticated identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ const userPoolId = "<User pool Id>";
 // Create an authentication helper instance using credentials from Cognito
 const authHelper = await amazonLocationAuthHelper.withIdentityPoolId(identityPoolId, {
   logins: {
-    [`cognito-idp.${region}.amazonaws.com/${userPoolId}`]: "conito-id-token"
+    [`cognito-idp.${region}.amazonaws.com/${userPoolId}`]: "cognito-id-token"
   }
 });
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,25 @@ const map = new maplibregl.Map({
 });
 ```
 
+alternatively, should you prefer to use authenticated identities you can modify the `withIdentityPoolId` signature to provide custom parameters:
+
+```javascript
+
+const userPoolId = "<User pool Id>";
+...
+
+// Create an authentication helper instance using credentials from Cognito
+const authHelper = await amazonLocationAuthHelper.withIdentityPoolId(identityPoolId, {
+  logins: {
+    [`cognito-idp.${region}.amazonaws.com/${userPoolId}`]: "conito-id-token"
+  }
+});
+
+...
+```
+
+You can retrieve the `cognito-id-token` form the user session [using Amplify](https://docs.amplify.aws/javascript/build-a-backend/auth/manage-user-session/#retrieve-a-user-session)
+
 ## Documentation
 
 Detailed documentation can be generated under `docs/index.html` by running:

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ const authHelper = await amazonLocationAuthHelper.withIdentityPoolId(identityPoo
 ...
 ```
 
-You can retrieve the `cognito-id-token` form the user session [using Amplify](https://docs.amplify.aws/javascript/build-a-backend/auth/manage-user-session/#retrieve-a-user-session)
+You can retrieve the `cognito-id-token` from the user session [using Amplify](https://docs.amplify.aws/javascript/build-a-backend/auth/manage-user-session/#retrieve-a-user-session)
 
 ## Documentation
 

--- a/src/cognito/index.test.ts
+++ b/src/cognito/index.test.ts
@@ -94,6 +94,23 @@ describe("AuthHelper for Cognito", () => {
     });
   });
 
+  it("should not use region and identityPoolId provided inside the options", async () => {
+    // region and identity pool id provided in the options are ignored since it's inferred from the cognitoIdentityPoolId
+    await withIdentityPoolId(cognitoIdentityPoolId, {
+      clientConfig: {
+        region: "unused-region",
+      },
+      identityPoolId: "unused-idp-id",
+    });
+    expect(fromCognitoIdentityPool).toHaveBeenCalledTimes(1);
+    expect(fromCognitoIdentityPool).toHaveBeenCalledWith({
+      identityPoolId: cognitoIdentityPoolId,
+      clientConfig: {
+        region,
+      },
+    });
+  });
+
   it("should refresh credentials in 1 hour minus 1 minute by default", async () => {
     const authHelper = await withIdentityPoolId(cognitoIdentityPoolId);
 

--- a/src/cognito/index.test.ts
+++ b/src/cognito/index.test.ts
@@ -54,6 +54,46 @@ describe("AuthHelper for Cognito", () => {
     });
   });
 
+  it("should get credentials from cognito using custom logins token", async () => {
+    await withIdentityPoolId(cognitoIdentityPoolId, {
+      logins: {
+        "cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>": "cognito-id-token",
+      },
+    });
+    expect(fromCognitoIdentityPool).toHaveBeenCalledTimes(1);
+    expect(fromCognitoIdentityPool).toHaveBeenCalledWith({
+      identityPoolId: cognitoIdentityPoolId,
+      clientConfig: {
+        region,
+      },
+      logins: {
+        "cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>": "cognito-id-token",
+      },
+    });
+  });
+
+  it("should get credentials from cognito using custom options with client config", async () => {
+    await withIdentityPoolId(cognitoIdentityPoolId, {
+      clientConfig: {
+        maxAttempts: 10,
+      },
+      logins: {
+        "cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>": "cognito-id-token",
+      },
+    });
+    expect(fromCognitoIdentityPool).toHaveBeenCalledTimes(1);
+    expect(fromCognitoIdentityPool).toHaveBeenCalledWith({
+      identityPoolId: cognitoIdentityPoolId,
+      clientConfig: {
+        region,
+        maxAttempts: 10,
+      },
+      logins: {
+        "cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>": "cognito-id-token",
+      },
+    });
+  });
+
   it("should refresh credentials in 1 hour minus 1 minute by default", async () => {
     const authHelper = await withIdentityPoolId(cognitoIdentityPoolId);
 

--- a/src/cognito/index.ts
+++ b/src/cognito/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MapAuthHelper, SDKAuthHelper } from "../common/types";
-import { fromCognitoIdentityPool } from "@aws-sdk/credential-providers";
+import { FromCognitoIdentityPoolParameters, fromCognitoIdentityPool } from "@aws-sdk/credential-providers";
 import { Signer } from "@aws-amplify/core";
 import { AwsCredentialIdentity } from "@aws-sdk/types";
 /**
@@ -10,11 +10,16 @@ import { AwsCredentialIdentity } from "@aws-sdk/types";
  *
  * @param identityPoolId Cognito Identity Pool Id
  */
-export async function withIdentityPoolId(identityPoolId: string): Promise<MapAuthHelper & SDKAuthHelper> {
+export async function withIdentityPoolId(
+  identityPoolId: string,
+  options?: Partial<FromCognitoIdentityPoolParameters>,
+): Promise<MapAuthHelper & SDKAuthHelper> {
   const region = identityPoolId.split(":")[0];
   const credentialsProvider = fromCognitoIdentityPool({
+    ...(options || {}),
     identityPoolId,
     clientConfig: {
+      ...(options && options.clientConfig ? options.clientConfig : {}),
       region,
     },
   });


### PR DESCRIPTION
_Issue #, if available:_ 
NA

_Description of changes:_

The current implementation of the `withIdentityPoolId` method does not allow to use authenticated identities to perform actions against the Amazon Location APIs (thus forcing to use only unauthenticated identities). This PR updates the signature of the method mentioned above to expose props that allow to customise the behaviour of the `fromCognitoIdentityPool` underlying API [ref](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts#L51). 

With this change is now possible to use authenticated identities [ref](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-integrating-user-pools-with-identity-pools.html#amazon-cognito-integrating-user-pools-with-identity-pools-using) to provide access to Amazon Location Service

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
