### PR TITLE
Add an empty `credentials` config value for `withAPIKey`

### DIFF
--- a/src/apikey/index.test.ts
+++ b/src/apikey/index.test.ts
@@ -55,4 +55,9 @@ describe("AuthHelper for APIKey", () => {
     const authHelper = await withAPIKey(API_KEY);
     expect("getCredentials" in authHelper).toBe(false);
   });
+
+  it("should provide an empty `credentials` config value", async () => {
+    const authHelper = await withAPIKey(API_KEY);
+    expect(await authHelper.getLocationClientConfig().credentials()).toEqual({});
+  });
 });

--- a/src/apikey/index.ts
+++ b/src/apikey/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { SDKAuthHelper } from "../common/types";
 
 /**
@@ -22,6 +23,8 @@ export async function withAPIKey(apiKey: string): Promise<SDKAuthHelper> {
           return requestToSign;
         },
       },
+      // Empty value to avoid calling the default credential providers chain
+      credentials: (async () => ({})) as AwsCredentialIdentityProvider,
     }),
   };
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AwsCredentialIdentity, Provider, RequestSigner } from "@aws-sdk/types";
+import { AwsCredentialIdentity, AwsCredentialIdentityProvider, RequestSigner } from "@aws-sdk/types";
 
 export interface MapAuthenticationOptions {
   transformRequest: (url: string, resourceType?: string) => { url: string };
@@ -9,7 +9,7 @@ export interface MapAuthenticationOptions {
 
 export interface LocationClientConfig {
   signer?: RequestSigner;
-  credentials?: Provider<AwsCredentialIdentity>;
+  credentials?: AwsCredentialIdentityProvider;
 }
 
 export type getMapAuthenticationOptionsFunc = () => MapAuthenticationOptions;


### PR DESCRIPTION
_Issue #, if available:_

aws/aws-sdk-js-v3#5808

_Description of changes:_

Add an empty `credentials` config value to avoid calling the default
credential providers chain.

The internals of the JSv3 SDK have been modified to support enhanced
identity and authentication features.

However, these internal changes are not compatible with custom config
`signer` behavior that do not match the expected [`@aws.auth#sigv4`](https://smithy.io/2.0/aws/aws-auth.html#aws-auth-sigv4-trait)
auth scheme.

_Testing:_

Testing is done E2E with the `@aws-sdk/client-location` client based on the repro in https://github.com/aws/aws-sdk-js-v3/issues/5808:

```javascript
// withAPIKey with new empty `credentials` value change
const { withAPIKey } = require("@aws/amazon-location-utilities-auth-helper");
const { LocationClient, SearchPlaceIndexForTextCommand } = require("@aws-sdk/client-location");

const params = {
  IndexName: "My-Location-Service-Place-Index",
  Text: "Calle Tomas Zerolo 21, La Orotava, Espania",
  FilterCountries : ["GBR", "IRL", "DNK", "ESP"],
  Language: "en",
  MaxResults: 1,
}

async function x() {
  const authHelper = await withAPIKey("ABC");
  const awsClient = new LocationClient({
    region: "us-east-1", 
    ...authHelper.getLocationClientConfig(),
  });

  const command = new SearchPlaceIndexForTextCommand(params);
  const response = await awsClient.send(command);

  console.log("Subregion: " + response.Results[0].Place.SubRegion)
}

try{
  console.log(require("@aws-sdk/client-location/package.json").version);
  x()
} catch(error) {
  console.log(error)
}
```

Instead of the unexpected error message from invoking the default credential providers chain with no configured `credentials`:

```log
CredentialsProviderError: Could not load credentials from any providers
```

The expected error message is emitted (if the user was authenticated, the command invocation would succeed):

```log
AccessDeniedException: User is not authorized to access this resource with an explicit deny
```

This was tested with 2 `@aws-sdk/client-location` versions: `3.511.0` (reported good version) and `3.513.0` (reported issue version)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
