### PR TITLE
Bumped version to 1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-utilities-auth-helper",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-utilities-auth-helper",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-utilities-auth-helper",
   "description": "Amazon Location Utilities - Authentication Helper for JavaScript",
   "license": "Apache-2.0",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
_Description of changes:_

Bumped version to `1.0.6` after reducing dependencies from ~280MB -> 19MB: https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/35
