### PR TITLE
Refine the transform interceptor to only match amazon location service URLs

### DIFF
--- a/src/cognito/index.test.ts
+++ b/src/cognito/index.test.ts
@@ -14,6 +14,7 @@ describe("AuthHelper for Cognito", () => {
   const cognitoIdentityPoolId = `${region}:TEST-IDENTITY-POOL-ID`;
   const url = "https://maps.geo.us-west-2.amazonaws.com/";
   const nonAWSUrl = "https://example.com/";
+  const nonLocationAWSUrl = "https://my.cool.service.us-west-2.amazonaws.com/";
   const mockedCredentials = {
     identityId: "identityId",
     accessKeyId: "accessKeyId",
@@ -168,6 +169,15 @@ describe("AuthHelper for Cognito", () => {
 
     expect(transformRequest(nonAWSUrl)).toStrictEqual({
       url: nonAWSUrl,
+    });
+  });
+
+  it("getMapAuthenticationOptions transformRequest function should pass-through AWS Urls that aren't for the Amazon Location Service unchanged", async () => {
+    const authHelper = await withIdentityPoolId(cognitoIdentityPoolId);
+    const transformRequest = authHelper.getMapAuthenticationOptions().transformRequest;
+
+    expect(transformRequest(nonLocationAWSUrl)).toStrictEqual({
+      url: nonLocationAWSUrl,
     });
   });
 

--- a/src/cognito/index.ts
+++ b/src/cognito/index.ts
@@ -42,8 +42,8 @@ export async function withIdentityPoolId(
   return {
     getMapAuthenticationOptions: () => ({
       transformRequest: (url: string) => {
-        // Only sign aws location service URLs
-        if (url.match("(http|https)://(.*).geo.(.*).amazonaws.com")) {
+        // Only sign Amazon Location Service URLs
+        if (url.match("https://maps.(geo|geo-fips).(.*).amazonaws.com")) {
           return {
             url: Signer.signUrl(url, region, {
               access_key: credentials.accessKeyId,

--- a/src/cognito/index.ts
+++ b/src/cognito/index.ts
@@ -42,8 +42,8 @@ export async function withIdentityPoolId(
   return {
     getMapAuthenticationOptions: () => ({
       transformRequest: (url: string) => {
-        // Only sign aws URLs
-        if (url.includes("amazonaws.com")) {
+        // Only sign aws location service URLs
+        if (url.match("(http|https)://(.*).geo.(.*).amazonaws.com")) {
           return {
             url: Signer.signUrl(url, region, {
               access_key: credentials.accessKeyId,


### PR DESCRIPTION
## Description
Refined the transform request interceptor to only modify Amazon Location Service URLs, instead of any `*amazonaws.com` URL. This will allow users to add custom layers to their map that might be hosted on their own AWS service to not be transformed inadvertently.

## Testing
Extended unit tests to capture this specificity.