### PR TITLE
Update url match to include safer regex checking

### DIFF
--- a/src/cognito/index.ts
+++ b/src/cognito/index.ts
@@ -43,7 +43,7 @@ export async function withIdentityPoolId(
     getMapAuthenticationOptions: () => ({
       transformRequest: (url: string) => {
         // Only sign Amazon Location Service URLs
-        if (url.match("https://maps.(geo|geo-fips).(.*).amazonaws.com")) {
+        if (url.match(/^https:\/\/maps\.(geo|geo-fips)\.[a-zA-Z0-9-]+\.(amazonaws\.com)$/)) {
           return {
             url: Signer.signUrl(url, region, {
               access_key: credentials.accessKeyId,


### PR DESCRIPTION
_Issue #, if available:_ 
Codescanning vulnerabilities: 
https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/security/code-scanning/2
https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/security/code-scanning/1

_Description of changes:_I have updated the url matching to use stricter regex so that our matching is more accurate. This addresses mutliple codescanning vulnerabilties that are open

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
