### PR TITLE
Added support for cognito standalone maps URLs

### DIFF
--- a/src/cognito/index.ts
+++ b/src/cognito/index.ts
@@ -49,8 +49,29 @@ export async function withIdentityPoolId(
       transformRequest: (url: string) => {
         // Only sign Amazon Location Service URLs
         if (url.match(/^https:\/\/maps\.(geo|geo-fips)\.[a-z0-9-]+\.(amazonaws\.com)/)) {
+          const urlObj = new URL(url);
+
+          // Split the pathname into parts, using the filter(Boolean) to ignore any empty parts,
+          // since the first item will be empty because the pathname looks like:
+          //    /v2/styles/Standard/descriptor
+          const pathParts = urlObj.pathname.split("/").filter(Boolean);
+
+          // The signing service name for the standalone Maps SDK is "geo-maps"
+          let serviceName = "geo-maps";
+          if (pathParts?.[0] == "v2") {
+            // For this case, we only need to sign the map tiles, so we
+            // can return the original url if it is for descriptor, sprites, or glyphs
+            if (pathParts?.[1] != "tiles") {
+              return { url };
+            }
+          } else {
+            // The signing service name for the consolidated Location Client is "geo"
+            // In this case, we need to sign all URLs (sprites, glyphs, map tiles)
+            serviceName = "geo";
+          }
+
           return {
-            url: Signer.signUrl(url, region, {
+            url: Signer.signUrl(url, region, serviceName, {
               access_key: credentials.accessKeyId,
               secret_key: credentials.secretAccessKey,
               session_token: credentials.sessionToken,

--- a/src/utils/signer.ts
+++ b/src/utils/signer.ts
@@ -83,7 +83,7 @@ interface Presignable extends Pick<HttpRequest, "body" | "url"> {
 }
 
 export class Signer {
-  static signUrl(urlToSign: string, region: string, accessInfo: any): string {
+  static signUrl(urlToSign: string, region: string, serviceName: string, accessInfo: any): string {
     const method = "GET";
     let body: undefined;
 
@@ -93,7 +93,7 @@ export class Signer {
       url: new URL(urlToSign),
     };
 
-    const options = getOptions(urlToSign, region, accessInfo);
+    const options = getOptions(urlToSign, region, serviceName, accessInfo);
     const signedUrl = presignUrl(presignable, options);
 
     return signedUrl.toString();
@@ -103,6 +103,7 @@ export class Signer {
 const getOptions = (
   url: string,
   region: string,
+  serviceName: string,
   accessInfo: { access_key: string; secret_key: string; session_token: string },
 ) => {
   const { access_key, secret_key, session_token } = accessInfo ?? {};
@@ -112,14 +113,11 @@ const getOptions = (
     sessionToken: session_token,
   };
 
-  // Service hard-coded to "geo" for our purposes
-  const service = "geo";
-
   return {
     credentials,
     signingDate: new Date(),
     signingRegion: region,
-    signingService: service,
+    signingService: serviceName,
   };
 };
 


### PR DESCRIPTION
## Description
When using an Amazon Cognito Identity Pool ID for authentication with the standalone Maps SDK URL, the signing service name is `geo-maps`, instead of just `geo`. Updated the logic to handle this, and also restricted the signing for standalone Maps SDK URLs to only be done when fetching the tiles.

## Testing
Updated the unit tests to handle both standalone Maps SDK URLs and consolidated Location SDK URLs. Added checks to verify the signing is working on all the appropriate resources (descriptor, sprites, glyphs, tiles) for the consolidated Location SDK case, and only signing tiles when using a standalone Maps SDK Url. Also added check to verify the credential is using the correct signing service name.

Also tested with local examples to verify it works for both cases.