### PR TITLE
Updated withAPIKey to be synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import { GeoPlacesClient, GeocodeCommand } from "@aws-sdk/geo-places-client";
 import { withAPIKey } from "@aws/amazon-location-utilities-auth-helper";
 
 // Create an authentication helper instance using an API key and region
-const authHelper = await withAPIKey("<API Key>", "<Region>");
+const authHelper = withAPIKey("<API Key>", "<Region>");
 
 // Configures the client to use API keys when making supported requests
 const client = new GeoPlacesClient(authHelper.getClientConfig());
@@ -64,7 +64,7 @@ import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/geo-routes-cli
 import { withAPIKey } from "@aws/amazon-location-utilities-auth-helper";
 
 // Create an authentication helper instance using an API key and region
-const authHelper = await withAPIKey("<API Key>", "<Region>");
+const authHelper = withAPIKey("<API Key>", "<Region>");
 
 // Configures the client to use API keys when making supported requests
 const client = new GeoRoutesClient(authHelper.getClientConfig());
@@ -87,7 +87,7 @@ import { LocationClient, ListGeofencesCommand } from "@aws-sdk/client-location";
 import { withAPIKey } from "@aws/amazon-location-utilities-auth-helper";
 
 // Create an authentication helper instance using an API key and region
-const authHelper = await withAPIKey("<API Key>", "<Region>");
+const authHelper = withAPIKey("<API Key>", "<Region>");
 
 // Configures the client to use API keys when making supported requests
 const client = new LocationClient(authHelper.getClientConfig());
@@ -181,7 +181,7 @@ This example uses the Amazon Location Client to make a request that that authent
 
 ```javascript
 // Create an authentication helper instance using an API key and region
-const authHelper = await amazonLocationClient.withAPIKey("<API Key>", "<Region>");
+const authHelper = amazonLocationClient.withAPIKey("<API Key>", "<Region>");
 
 // Configures the client to use API keys when making supported requests
 const client = new amazonLocationClient.GeoRoutesClient(authHelper.getClientConfig());
@@ -289,7 +289,7 @@ npm run typedoc
 Creates an auth helper instance using API key (and region, optionally).
 
 ```javascript
-const authHelper = await withAPIKey(apiKey, region);
+const authHelper = withAPIKey(apiKey, region);
 ```
 
 ### `withIdentityPoolId`

--- a/src/apikey/index.test.ts
+++ b/src/apikey/index.test.ts
@@ -20,7 +20,7 @@ describe("AuthHelper for APIKey", () => {
       headers: {},
     };
     expect(
-      await signer.sign({
+      await signer?.sign({
         ...request,
         query,
       }),
@@ -29,6 +29,34 @@ describe("AuthHelper for APIKey", () => {
       query: expectedQuery,
     });
   });
+
+  it.each([
+    [{}, { key: API_KEY }],
+    [{ other: "value" }, { other: "value", key: API_KEY }],
+    [null, { key: API_KEY }],
+  ])(
+    "getLocationClientConfig should provide a signer to the query when using synchronous withAPIKey",
+    async (query, expectedQuery) => {
+      const authHelper = withAPIKey(API_KEY);
+      const signer = authHelper.getLocationClientConfig().signer;
+      const request = {
+        hostname: "amazonaws.com",
+        path: "/",
+        protocol: "https",
+        method: "GET",
+        headers: {},
+      };
+      expect(
+        await signer?.sign({
+          ...request,
+          query,
+        }),
+      ).toStrictEqual({
+        ...request,
+        query: expectedQuery,
+      });
+    },
+  );
 
   it("APIKey provided by getLocationClientConfig should be overridden by one set in the command", async () => {
     const authHelper = await withAPIKey(API_KEY);

--- a/src/apikey/index.ts
+++ b/src/apikey/index.ts
@@ -10,7 +10,7 @@ import { LocationClientConfig, SDKAuthHelper } from "../common/types";
  *
  * @param apiKey APIKey
  */
-export async function withAPIKey(apiKey: string, region?: string): Promise<SDKAuthHelper> {
+export function withAPIKey(apiKey: string, region?: string): SDKAuthHelper {
   const clientConfig: LocationClientConfig = {
     signer: {
       sign: async (requestToSign) => {


### PR DESCRIPTION
## Description
Removed async requirement from `withAPIKey`, since there is no asynchronous action being done in the method. We do need to keep `withIdentityPoolId` as async because fetching the credentials is an async operation.

Previous logic using `await withAPIKey` will still function as-is since `await` on a non-async function will return a `Promise` that resolves immediately.

## Testing
Updated unit tests to test `withAPIKey` usage in both async and sync calls.