### PR TITLE
Bumped version to `1.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.0
+
+### ✨ Features and improvements
+
+- Added support for cognito when using standalone Maps SDK URLs [#48](https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/48)
+- Modified `withAPIKey` API to be used synchronously [#49](https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/49)
+
 # 1.1.0
 
 ### ✨ Features and improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 
-- Added support for cognito when using standalone Maps SDK URLs [#48](https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/48)
+- Added support for Amazon Cognito when using standalone Maps SDK URLs [#48](https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/48)
 - Modified `withAPIKey` API to be used synchronously [#49](https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/49)
 
 # 1.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-utilities-auth-helper",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-utilities-auth-helper",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-utilities-auth-helper",
   "description": "Amazon Location Utilities - Authentication Helper for JavaScript",
   "license": "Apache-2.0",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
## Description
Bumped version to `1.2.0` for adding support for cognito with standalone Maps SDK URLs and `withAPIKey` synchronous modification.