### PR TITLE
Extended regex match for additional future endpoints

### DIFF
--- a/src/cognito/index.ts
+++ b/src/cognito/index.ts
@@ -48,7 +48,7 @@ export async function withIdentityPoolId(
     getMapAuthenticationOptions: () => ({
       transformRequest: (url: string, resourceType?: string) => {
         // Only sign Amazon Location Service URLs
-        if (url.match(/^https:\/\/maps\.(geo|geo-fips)\.[a-z0-9-]+\.(amazonaws\.com)/)) {
+        if (url.match(/^https:\/\/maps\.(geo|geo-fips)\.[a-z0-9-]+\.(amazonaws\.com|api\.aws)/)) {
           const urlObj = new URL(url);
 
           // Split the pathname into parts, using the filter(Boolean) to ignore any empty parts,


### PR DESCRIPTION
## Description
Extended cognito maps authentication `transformRequest` logic to match additional future endpoints.

## Testing
Added unit tests to exercise new logic for both consolidated Location maps requests and standalone Maps requests. Also updated several comments/descriptions in the unit tests.