### PR TITLE
Bump new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.2
+
+### ✨ Features and improvements
+
+- Updated all dependencies to latest versions as part of resolving @smithy/core conflict [#55](https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/55)
+
 # 1.2.1
 
 ### ✨ Features and improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-utilities-auth-helper",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-utilities-auth-helper",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-utilities-auth-helper",
   "description": "Amazon Location Utilities - Authentication Helper for JavaScript",
   "license": "Apache-2.0",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
### Description
New version release bump to `1.2.2` so that we can release the change updating all dependencies to latest versions:

https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/pull/55

### Testing
Ran unit tests and verified they all pass. Tested in local sample to verify the auth-helper still returns a valid configuration to create a client with.