### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   # cancel jobs on PRs only
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/security/code-scanning/3](https://github.com/aws-geospatial/amazon-location-utilities-auth-helper-js/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the steps in the workflow. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
