### PR TITLE
Fixed incorrect package imports in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ These examples showcase importing our libraries in modules, and then using a bun
 This example uses the standalone [Places](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-amzn-geoplaces-client/) SDK to make a request that authenticates using API keys.
 
 ```console
-npm install @aws-sdk/geo-places-client
+npm install @aws-sdk/client-geo-places
 ```
 
 ```javascript
 // Import from the AWS JavaScript SDK V3 (GeoPlacesClient)
-import { GeoPlacesClient, GeocodeCommand } from "@aws-sdk/geo-places-client";
+import { GeoPlacesClient, GeocodeCommand } from "@aws-sdk/client-geo-places";
 // Import the utility functions
 import { withAPIKey } from "@aws/amazon-location-utilities-auth-helper";
 
@@ -54,12 +54,12 @@ const response = await client.send(command);
 This example uses the standalone [Routes](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-amzn-georoutes-client/) SDK to make a request that authenticates using API keys.
 
 ```console
-npm install @aws-sdk/geo-routes-client
+npm install @aws-sdk/client-geo-routes
 ```
 
 ```javascript
 // Import from the AWS JavaScript SDK V3 (GeoRoutesClient)
-import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/geo-routes-client";
+import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/client-geo-routes";
 // Import the utility functions
 import { withAPIKey } from "@aws/amazon-location-utilities-auth-helper";
 
@@ -100,12 +100,12 @@ const response = await client.send(command);
 This example uses the standalone [Routes](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-amzn-georoutes-client/) SDK to make a request that that authenticates using Amazon Cognito.
 
 ```console
-npm install @aws-sdk/geo-routes-client
+npm install @aws-sdk/client-geo-routes
 ```
 
 ```javascript
 // Import from the AWS JavaScript SDK V3 (GeoRoutesClient)
-import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/geo-routes-client";
+import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/client-geo-routes";
 // Import the utility functions
 import { withIdentityPoolId } from "@aws/amazon-location-utilities-auth-helper";
 
@@ -123,12 +123,12 @@ const response = await client.send(command);
 This example uses the standalone [Routes](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-amzn-georoutes-client/) SDK to make a request that authenticates using a custom credential provider.
 
 ```console
-npm install @aws-sdk/geo-routes-client
+npm install @aws-sdk/client-geo-routes
 ```
 
 ```javascript
 // Import from the AWS JavaScript SDK V3 (GeoRoutesClient)
-import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/geo-routes-client";
+import { GeoRoutesClient, CalculateRoutesCommand } from "@aws-sdk/client-geo-routes";
 // Import the utility functions
 import { withCredentialProvider } from "@aws/amazon-location-utilities-auth-helper";
 


### PR DESCRIPTION
### Description
Fixed incorrect package imports in our `README` (has the `-client` as a suffix, but they actually all have a `client-` prefix).